### PR TITLE
fix test config so that backends are optional

### DIFF
--- a/README_dtest.py
+++ b/README_dtest.py
@@ -1,0 +1,6 @@
+from nose import SkipTest
+from tests import get_engine
+
+def setup(mod):
+    global engine
+    engine = get_engine('pg-db')

--- a/setup.cfg.tmpl
+++ b/setup.cfg.tmpl
@@ -3,6 +3,8 @@ with-coverage = True
 cover-package = sqla_hierarchy
 with-doctest = True
 doctest-extension = rst
+doctest-fixtures = _dtest
+
 
 [dburi]
 # instructions:

--- a/setup.cfg.tmpl
+++ b/setup.cfg.tmpl
@@ -5,6 +5,15 @@ with-doctest = True
 doctest-extension = rst
 
 [dburi]
-# rename this file to setup.cfg and add here all databases strings
-pg-db = user:pass@localhost/db
-oracle-db = user:pass@localhost/db
+# instructions:
+# 1. copy this file to setup.cfg
+# 2. fill in URL strings as needed.
+# 3. Comment out those configurations that aren't supported
+# on the target platform - tests which rely upon them will
+# be skipped.
+
+# postgresql
+pg-db = postgresql://user:pass@localhost/db
+
+# oracle
+#oracle-db = oracle://user:pass@localhost/db

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,13 @@
+from nose import SkipTest
+import ConfigParser
+from sqlalchemy import create_engine
+
+
+def get_engine(name):
+    config = ConfigParser.ConfigParser()
+    config.read('setup.cfg')
+    try:
+        uri = config.get('dburi', name)
+    except ConfigParser.NoOptionError:
+        raise SkipTest("No database configuration for %s is defined" % name)
+    return create_engine(uri)


### PR DESCRIPTION
hello there -

I've been tasked with debugging a sqla_hierarchy issue present at http://www.sqlalchemy.org/trac/ticket/2558.   I don't know the nature of the issue yet but I see that sqla_hierarchy makes elaborate use of SQLA expression constructs, so it's very likely I'll need to modify sqla_hierarchy to be compatible with upcoming SQLAlchemy releases (including 0.7.9).   To that end I can easily add sqla_hierarchy to a new Jenkins environment I've been building (see http://jenkins-stage.sqlalchemy.org/) however the build system for sqla_hierarchy needs to be more agile.  This pull request establishes each database config as optional, emitting SkipTest for those platforms not installed.  We have separate build nodes for Oracle and PG, basically.
